### PR TITLE
Fix options

### DIFF
--- a/child.js
+++ b/child.js
@@ -1,4 +1,5 @@
 const { FSWatcher } = require('chokidar');
+const optionsTransfer = require('./options');
 
 let watcher;
 
@@ -10,6 +11,7 @@ function sendEvent(event, path) {
 }
 
 function init(options) {
+  options = optionsTransfer.decode(options);
   watcher = new FSWatcher(options);
   watcher.on('all', (event, path) => {
     sendEvent(event, path);

--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 const fork = require('child_process').fork;
 const { EventEmitter } = require('events');
 const path = require('path');
+const optionsTransfer = require('./options');
 
 class Watcher extends EventEmitter {
   constructor(options = {}) {
     super();
-    this.options = options;
+    this.options = optionsTransfer.encode(options);
     this.watchedPaths = new Set();
     this.child = null;
     this.ready = false;

--- a/options.js
+++ b/options.js
@@ -1,0 +1,47 @@
+function type(o) {
+  return Object.prototype.toString.call(o).slice(8, -1);
+}
+
+/*
+input:
+{a:1, b:/x/, c:'d', f:{g:1}, h:[1,2,3]}
+
+output:
+{a:1, b:x, c:'d', __regIndexs__: [0]}
+*/
+function encode(o) {
+  if (o && o.ignored) {
+    const ignoredType = type(o.ignored);
+    if (ignoredType !== 'Array') {
+      o.ignored = [o.ignored];
+    }
+
+    o.ignored.forEach((val, index) => {
+      const valType = type(val)
+      if (valType === 'RegExp') {
+        o.ignored[index] = val.source;
+        if (!o.__regIndexs) {
+          o.__regIndexs = [];
+        }
+        o.__regIndexs.push(index);
+      }
+    });
+  }
+
+  return o;
+}
+
+function decode(o) {
+  if (o && o.ignored && o.__regIndexs) {
+    for (let index of o.__regIndexs) {
+      o.ignored[index] = new RegExp(o.ignored[index]);
+    }
+  }
+
+  delete o.__regIndexs;
+
+  return o;
+}
+
+exports.encode = encode
+exports.decode = decode

--- a/options.js
+++ b/options.js
@@ -4,10 +4,10 @@ function type(o) {
 
 /*
 input:
-{a:1, b:/x/, c:'d', f:{g:1}, h:[1,2,3]}
+{a:1, ignored:/x/, c:'d'}
 
 output:
-{a:1, b:x, c:'d', __regIndexs__: [0]}
+{a:1, ignored:['x'], c:'d', __regIndexs__: [0]}
 */
 function encode(o) {
   if (o && o.ignored) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -112,4 +112,29 @@ describe('basic chokidar tests', function() {
 
     watcher.close();
   });
+
+  it('Should pass init options with ignored correct', async () => {
+    let watcher = new FSWatcher({
+      ignored: /file/
+    });
+
+    let filepath = path.join(tmpFolder, 'file1.txt');
+    await fs.writeFile(filepath, 'this is a text document');
+
+    watcher.add(filepath);
+    let changed = false;
+    watcher.once('change', () => {
+      changed = true;
+    });
+    if (!watcher.ready) {
+      await new Promise(resolve => watcher.once('ready', resolve));
+    }
+    await new Promise(resolve => setTimeout(resolve, 250));
+    await fs.writeFile(filepath, 'this is not a text document');
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    assert(!changed, 'File should not be flagged as changed.');
+
+    watcher.close();
+  });
 });


### PR DESCRIPTION
FSWtacher init options passed through `process.send`, Node.js use `JSON.stringify` to parse Object into String，during this process, when options.ignored contain a regexp expression, it will transform to `{}`， this PR make regexp pass without transform into `{}`