### PR TITLE
Fixed inspect bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,18 @@ class Watcher extends EventEmitter {
 
   startchild() {
     if (this.child) return;
+    
+    let filteredArgs = process.execArgv.filter(
+      v => !/^--(debug|inspect)/.test(v)
+    );
 
-    this.child = fork(path.join(__dirname, 'child'));
+    let options = {
+      execArgv: filteredArgs,
+      env: process.env,
+      cwd: process.cwd()
+    };
+
+    this.child = fork(path.join(__dirname, 'child'), process.argv, options);
 
     if (this.watchedPaths.size > 0) {
       this.sendCommand('add', [Array.from(this.watchedPaths)]);


### PR DESCRIPTION
This package breaks inspect usage in parcel, please add this code, it is the same as in parcel itself:
https://github.com/parcel-bundler/parcel/blob/master/src/workerfarm/Worker.js#L32

In any case I would recommend to move this code to parcel package itself, it is highly sensitive and considered as core logic (at least by my book).